### PR TITLE
Fix build with Qt 5.11_beta3 (dropping qt5_use_modules)

### DIFF
--- a/plugins/Ubuntu/Thumbnailer.0.1/CMakeLists.txt
+++ b/plugins/Ubuntu/Thumbnailer.0.1/CMakeLists.txt
@@ -9,7 +9,6 @@ add_library(thumbnailer-qml-static STATIC
   thumbnailgenerator.cpp
   )
 set_target_properties(thumbnailer-qml-static PROPERTIES AUTOMOC TRUE)
-qt5_use_modules(thumbnailer-qml-static Qml Quick)
 target_link_libraries(thumbnailer-qml-static ${LIBTHUMBNAILER_QT} Qt5::Qml Qt5::Quick)
 
 add_library(thumbnailer-qml MODULE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,6 @@ add_library(thumbnailer-static STATIC
     ${CMAKE_SOURCE_DIR}/include/internal/ubuntuserverdownloader.h
 )
 
-qt5_use_modules(thumbnailer-static Core Network)
 set_target_properties(thumbnailer-static PROPERTIES AUTOMOC TRUE)
 
 target_link_libraries(thumbnailer-static

--- a/src/libthumbnailer-qt/CMakeLists.txt
+++ b/src/libthumbnailer-qt/CMakeLists.txt
@@ -23,7 +23,6 @@ set_target_properties(${LIBTHUMBNAILER_QT} PROPERTIES
                       LINK_FLAGS "${ldflags} -Wl,--version-script,${symbol_map} ")
 set_target_properties(${LIBTHUMBNAILER_QT} PROPERTIES LINK_DEPENDS ${symbol_map})
 
-qt5_use_modules(${LIBTHUMBNAILER_QT} DBus Gui)
 target_link_libraries(${LIBTHUMBNAILER_QT} thumbnailer-static Qt5::DBus Qt5::Gui)
 set_target_properties(${LIBTHUMBNAILER_QT} PROPERTIES AUTOMOC TRUE)
 add_dependencies(${LIBTHUMBNAILER_QT} thumbnailer-service)

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -17,8 +17,7 @@ add_executable(thumbnailer-service
   ${adaptor_files}
   ${interface_files}
 )
-
-qt5_use_modules(thumbnailer-service DBus Concurrent)
+find_package(Qt5Concurrent REQUIRED)
 target_link_libraries(thumbnailer-service thumbnailer-static Qt5::DBus Qt5::Concurrent)
 set_target_properties(thumbnailer-service PROPERTIES AUTOMOC TRUE)
 add_dependencies(thumbnailer-service vs-thumb)

--- a/src/thumbnailer-admin/CMakeLists.txt
+++ b/src/thumbnailer-admin/CMakeLists.txt
@@ -25,7 +25,6 @@ add_executable(thumbnailer-admin
     ${CMAKE_SOURCE_DIR}/src/service/stats.cpp
     ${interface_files}
 )
-qt5_use_modules(thumbnailer-admin DBus)
 target_link_libraries(thumbnailer-admin thumbnailer-static Qt5::DBus ${CACHE_DEPS_LDFLAGS} ${Boost_LIBRARIES})
 add_dependencies(thumbnailer-admin thumbnailer-service)
 

--- a/src/vs-thumb/CMakeLists.txt
+++ b/src/vs-thumb/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(vs-thumb-static STATIC
     thumbnailextractor.cpp
 )
-qt5_use_modules(vs-thumb-static Core)
+target_link_libraries(vs-thumb-static Qt5::Core)
 
 add_executable(vs-thumb
     vs-thumb.cpp


### PR DESCRIPTION
Closes #1 

Tested on Arch GNU/Linux.

`target_link_libraries` was already defined in some cases, so removing `qt_use_modules` was enough.