### PR TITLE
Fix build with Qt 5.11_beta3 (dropping qt5_use_modules) (Bring the patch from bionic branch)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,65 +1,10 @@
-pipeline {
-  agent any
-  stages {
-    stage('Build source') {
-      steps {
-        sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-      }
-    }
-    stage('Build binary - armhf') {
-      steps {
-        parallel(
-          "Build binary - armhf": {
-            node(label: 'arm64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="armhf"
-build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
+@Library('ubports-build-tools') _
 
+buildAndProvideDebianPackage()
 
-          },
-          "Build binary - arm64": {
-            node(label: 'arm64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="arm64"
-    build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
-          },
-          "Build binary - amd64": {
-            node(label: 'amd64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="amd64"
-    build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
-          }
-        )
-      }
-    }
-    stage('Results') {
-      steps {
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-        unstash 'build-armhf'
-        unstash 'build-arm64'
-        unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
-        sh '''/usr/bin/build-repo.sh'''
-      }
-    }
-    stage('Cleanup') {
-      steps {
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-      }
-    }
-  }
-}
+// Or if the package consists entirely of arch-independent packages:
+// (optional optimization, will confuse BlueOcean's live view at build stage)
+// buildAndProvideDebianPackage(/* isArchIndependent */ true)
+
+// Optionally, to skip building on some architectures (amd64 is always built):
+// buildAndProvideDebianPackage(false, /* ignoredArchs */ ['arm64'])

--- a/plugins/Ubuntu/Thumbnailer.0.1/CMakeLists.txt
+++ b/plugins/Ubuntu/Thumbnailer.0.1/CMakeLists.txt
@@ -9,7 +9,6 @@ add_library(thumbnailer-qml-static STATIC
   thumbnailgenerator.cpp
   )
 set_target_properties(thumbnailer-qml-static PROPERTIES AUTOMOC TRUE)
-qt5_use_modules(thumbnailer-qml-static Qml Quick)
 target_link_libraries(thumbnailer-qml-static ${LIBTHUMBNAILER_QT} Qt5::Qml Qt5::Quick)
 
 add_library(thumbnailer-qml MODULE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,6 @@ add_library(thumbnailer-static STATIC
     ${CMAKE_SOURCE_DIR}/include/internal/ubuntuserverdownloader.h
 )
 
-qt5_use_modules(thumbnailer-static Core Network)
 set_target_properties(thumbnailer-static PROPERTIES AUTOMOC TRUE)
 
 target_link_libraries(thumbnailer-static

--- a/src/libthumbnailer-qt/CMakeLists.txt
+++ b/src/libthumbnailer-qt/CMakeLists.txt
@@ -23,7 +23,6 @@ set_target_properties(${LIBTHUMBNAILER_QT} PROPERTIES
                       LINK_FLAGS "${ldflags} -Wl,--version-script,${symbol_map} ")
 set_target_properties(${LIBTHUMBNAILER_QT} PROPERTIES LINK_DEPENDS ${symbol_map})
 
-qt5_use_modules(${LIBTHUMBNAILER_QT} DBus Gui)
 target_link_libraries(${LIBTHUMBNAILER_QT} thumbnailer-static Qt5::DBus Qt5::Gui)
 set_target_properties(${LIBTHUMBNAILER_QT} PROPERTIES AUTOMOC TRUE)
 add_dependencies(${LIBTHUMBNAILER_QT} thumbnailer-service)

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -17,8 +17,7 @@ add_executable(thumbnailer-service
   ${adaptor_files}
   ${interface_files}
 )
-
-qt5_use_modules(thumbnailer-service DBus Concurrent)
+find_package(Qt5Concurrent REQUIRED)
 target_link_libraries(thumbnailer-service thumbnailer-static Qt5::DBus Qt5::Concurrent)
 set_target_properties(thumbnailer-service PROPERTIES AUTOMOC TRUE)
 add_dependencies(thumbnailer-service vs-thumb)

--- a/src/thumbnailer-admin/CMakeLists.txt
+++ b/src/thumbnailer-admin/CMakeLists.txt
@@ -25,7 +25,6 @@ add_executable(thumbnailer-admin
     ${CMAKE_SOURCE_DIR}/src/service/stats.cpp
     ${interface_files}
 )
-qt5_use_modules(thumbnailer-admin DBus)
 target_link_libraries(thumbnailer-admin thumbnailer-static Qt5::DBus ${CACHE_DEPS_LDFLAGS} ${Boost_LIBRARIES})
 add_dependencies(thumbnailer-admin thumbnailer-service)
 

--- a/src/vs-thumb/CMakeLists.txt
+++ b/src/vs-thumb/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(vs-thumb-static STATIC
     thumbnailextractor.cpp
 )
-qt5_use_modules(vs-thumb-static Core)
+target_link_libraries(vs-thumb-static Qt5::Core)
 
 add_executable(vs-thumb
     vs-thumb.cpp


### PR DESCRIPTION
Now that our xenial is on Qt 5.12, this is required.